### PR TITLE
add language switch

### DIFF
--- a/Wisp_English.py
+++ b/Wisp_English.py
@@ -7,13 +7,15 @@ from pathlib import Path
 from pydub import AudioSegment
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
 import os
+from lang import get_text as tx
+
 
 class MainWindow(QWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs) 
 
         # set the window title
-        self.setWindowTitle("Transcription software Whisper:")
+        self.setWindowTitle(tx("window_title"))
         self.setGeometry(100, 100, 400, 100)
 
         # Create a layout
@@ -95,6 +97,7 @@ class MainWindow(QWidget):
 
         # show the windows
         self.show()
+
     def record_speech(self):
         "This method allows the user to record their own speech, starting and stopping a recording."
         if self.button_state == 'record':

--- a/Wisp_German.py
+++ b/Wisp_German.py
@@ -7,13 +7,14 @@ from pathlib import Path
 from pydub import AudioSegment
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
 import os
+from lang import get_text as tx
 
 class MainWindow(QWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs) 
 
         # set the window title
-        self.setWindowTitle("Transkriptionssoftware Whisper:")
+        self.setWindowTitle(tx("window_title"))
         self.setGeometry(100, 100, 400, 100)
 
         # Create a layout
@@ -95,6 +96,7 @@ class MainWindow(QWidget):
 
         # show the windows
         self.show()
+
     def record_speech(self):
         "This method allows the user to record their own speech, starting and stopping a recording."
         if self.button_state == 'record':

--- a/lang.py
+++ b/lang.py
@@ -1,0 +1,30 @@
+"""
+language switch module.
+
+Provides the TEXT dictionary containing the translation
+for all text elements in the GUI.
+"""
+import os
+import warnings
+
+
+# get language setting from environment variable
+LANG = os.getenv("LANG").upper() or "EN"
+LANG = "EN" if "EN" in LANG else "DE"
+
+TEXT_EN = {
+    "window_title": "Transcription software Whisper:",
+}
+
+TEXT_DE = {
+    "window_title": "Transkriptionssoftware Whisper:",
+}
+
+def get_text(key: str):
+    """returns a translated text element"""
+    if LANG == "EN" and key in TEXT_EN:
+        return TEXT_EN[key]
+    if LANG == "DE" and key in TEXT_DE:
+        return TEXT_DE[key]
+    warnings.warn(f"missing translation for key '{key}'")
+    return key


### PR DESCRIPTION
To date, the two Python files are mostly identical apart from the language.
To avoid maintaining both files, one could isolate all text elements.

I added a file 'lang.py' that contains an example how all text elements could be managed.

This change could make future refactorings a lot easier.